### PR TITLE
Non uniform discrete Fourier transform

### DIFF
--- a/SciDataTool/Functions/fft_functions.py
+++ b/SciDataTool/Functions/fft_functions.py
@@ -226,7 +226,7 @@ def comp_fftn(values, axes_list, is_real=True):
     is_non_uniform = False
     for axis in axes_list:
         if axis.transform == "fft":
-            if axis.corr_values is not None:
+            if axis.corr_values is not None:  # Timesteps
                 if not is_uniform(axis.corr_values):
                     is_non_uniform = True
                     axes_dict_non_uniform[axis.index] = [
@@ -236,13 +236,14 @@ def comp_fftn(values, axes_list, is_real=True):
                     # Keep only interpolation data
                     axis.values = axis.input_data
                     axis.input_data = None
-            elif axis.input_data is not None:
+                    continue
+            if axis.input_data is not None:
                 if not isin(axis.input_data, axis.values).all():
                     is_non_uniform = True
                     # Convert wavenumbers to frequencies if needed
                     frequencies = (
                         axis.input_data
-                        if axis.name == "time"
+                        if axis.name == "freqs"
                         else axis.input_data / (2 * pi)
                     )
                     axes_dict_non_uniform[axis.index] = [

--- a/SciDataTool/Functions/fft_functions.py
+++ b/SciDataTool/Functions/fft_functions.py
@@ -21,13 +21,17 @@ from numpy import (
     concatenate,
     conjugate,
     flip,
+    isin,
     append,
     take,
     insert,
     delete,
     abs as np_abs,
     angle as np_angle,
+    allclose,
 )
+
+from SciDataTool.Functions.nudft_functions import is_uniform, nudftn, inudftn
 
 
 def comp_fft_freqs(time, is_time, is_real):
@@ -212,46 +216,94 @@ def comp_fftn(values, axes_list, is_real=True):
     """
 
     axes = []
+    axes_dict_non_uniform = dict()
     shape = []
     is_onereal = False
     is_twice = False
     axis_names = [axis.name for axis in axes_list]
+
+    # Check if one or several axes is non-uniform
+    is_non_uniform = False
     for axis in axes_list:
         if axis.transform == "fft":
-            if is_real and axis.name == "freqs":
-                axes.append(axis.index)
-                shape.append(values.shape[axis.index])
-                is_onereal = True
-            elif (
-                is_real
-                and axis.name == "wavenumber"
-                and "freqs" not in axis_names
-                and min(axis.values) >= 0
-            ):
-                axes.append(axis.index)
-                shape.append(values.shape[axis.index])
-                is_twice = True
-            else:
-                axes = [axis.index] + axes
-                shape = [values.shape[axis.index]] + shape
-    size = array(shape).prod()
-    if is_onereal:
-        values_FT = rfftn(values, axes=axes)
-        slice_0 = take(values_FT, 0, axis=axes[-1])
-        slice_0 *= 0.5
-        other_values = delete(values_FT, 0, axis=axes[-1])
-        values_FT = insert(other_values, 0, slice_0, axis=axes[-1])
-        values_FT2 = 2.0 * fftshift(values_FT, axes=axes[:-1]) / size
-    elif is_twice:
-        values_FT = fftn(values, axes=axes)
-        slice_0 = take(values_FT, 0, axis=axes[-1])
-        slice_0 *= 0.5
-        other_values = delete(values_FT, 0, axis=axes[-1])
-        values_FT = insert(other_values, 0, slice_0, axis=axes[-1])
-        values_FT2 = 2.0 * fftshift(values_FT, axes=axes) / size
+            if axis.corr_values is not None:
+                if not is_uniform(axis.corr_values):
+                    is_non_uniform = True
+                    axes_dict_non_uniform[axis.index] = [
+                        axis.corr_values,
+                        axis.input_data,
+                    ]
+                    # Keep only interpolation data
+                    axis.values = axis.input_data
+                    axis.input_data = None
+            elif axis.input_data is not None:
+                if not isin(axis.input_data, axis.values).all():
+                    is_non_uniform = True
+                    # Convert wavenumbers to frequencies if needed
+                    frequencies = (
+                        axis.input_data
+                        if axis.name == "time"
+                        else axis.input_data / (2 * pi)
+                    )
+                    axes_dict_non_uniform[axis.index] = [
+                        axis.corr_values,
+                        frequencies,
+                    ]
+                    # Keep only interpolation data
+                    axis.values = axis.input_data
+                    axis.input_data = None
+
+    # Apply DFT on non-uniform axes
+    if is_non_uniform:
+        values = nudftn(values, axes_dict=axes_dict_non_uniform)
+
+    # Find other fft axes
+    for axis in axes_list:
+        if axis.index not in axes_dict_non_uniform:
+            if axis.transform == "fft":
+                if is_real and axis.name == "freqs":
+                    axes.append(axis.index)
+                    shape.append(values.shape[axis.index])
+                    is_onereal = True
+                elif (
+                    is_real
+                    and axis.name == "wavenumber"
+                    and "freqs" not in axis_names
+                    and min(axis.values) >= 0
+                ):
+                    axes.append(axis.index)
+                    shape.append(values.shape[axis.index])
+                    is_twice = True
+                else:
+                    axes = [axis.index] + axes
+                    shape = [values.shape[axis.index]] + shape
+    if axes != []:
+        size = array(shape).prod()
+        if is_onereal:
+            values_FT = rfftn(values, axes=axes)
+            # Do not multiply constant component by 2 (f=0)
+            if axes_list[axes[-1]].corr_values[0] == 0:
+                slice_0 = take(values_FT, 0, axis=axes[-1])
+                slice_0 *= 0.5
+                if is_twice:
+                    slice_0 *= 0.5
+                other_values = delete(values_FT, 0, axis=axes[-1])
+                values_FT = insert(other_values, 0, slice_0, axis=axes[-1])
+            values_FT2 = 2.0 * fftshift(values_FT, axes=axes[:-1]) / size
+            if is_twice:
+                values_FT2 *= 2.0
+        elif is_twice:
+            values_FT = fftn(values, axes=axes)
+            slice_0 = take(values_FT, 0, axis=axes[-1])
+            slice_0 *= 0.5
+            other_values = delete(values_FT, 0, axis=axes[-1])
+            values_FT = insert(other_values, 0, slice_0, axis=axes[-1])
+            values_FT2 = 2.0 * fftshift(values_FT, axes=axes) / size
+        else:
+            values_FT = fftn(values, axes=axes)
+            values_FT2 = fftshift(values_FT, axes=axes) / size
     else:
-        values_FT = fftn(values, axes=axes)
-        values_FT2 = fftshift(values_FT, axes=axes) / size
+        values_FT2 = values
     return values_FT2
 
 
@@ -293,7 +345,50 @@ def comp_ifftn(values, axes_list, is_real=True):
     is_onereal = False
     is_half = False
     axis_names = [axis.name for axis in axes_list]
+    # Check if one or several axes is non-uniform
+    axes_dict_non_uniform = {}
+
     for axis in axes_list:
+        if axis.transform == "ifft":
+            if axis.input_data is not None:
+                if not is_uniform(axis.input_data):
+                    # Data is at least non uniform in "space"
+                    axes_dict_non_uniform[axis.index] = [
+                        axis.input_data,
+                        axis.corr_values,
+                    ]
+                elif axis.corr_values is not None:
+                    # Compare frequencies of interest with fft frequencies
+                    freqs = comp_fft_freqs(
+                        axis.input_data, axis.name == "time", is_real
+                    )
+                    if len(freqs) == len(axis.corr_values) and not allclose(
+                        freqs,
+                        axis.corr_values,
+                        rtol=1e-5,
+                        atol=1e-8,
+                        equal_nan=False,
+                    ):
+                        # Data is at least non uniform in "frequency"
+                        # Convert wavenumbers to frequencies if needed
+                        frequencies = (
+                            axis.corr_values
+                            if axis.name == "time"
+                            else axis.corr_values / (2 * pi)
+                        )
+                        axes_dict_non_uniform[axis.index] = [
+                            axis.input_data,
+                            frequencies,
+                        ]
+
+    # Compute non uniform inverse Fourier Transform for axes
+    if axes_dict_non_uniform:
+        values = inudftn(values, axes_dict=axes_dict_non_uniform)
+
+    for axis in axes_list:
+        # Exclude non uniform axes
+        if axis.index in axes_dict_non_uniform:
+            continue
         if axis.transform == "ifft":
             if is_real and axis.name == "time":
                 axes.append(axis.index)
@@ -309,9 +404,13 @@ def comp_ifftn(values, axes_list, is_real=True):
     size = array(shape).prod()
     if is_onereal:
         values = values * size / 2
+        if is_half:
+            values *= 0.5
         values_shift = ifftshift(values, axes=axes[:-1])
         slice_0 = take(values_shift, 0, axis=axes[-1])
         slice_0 *= 2
+        if is_half:
+            slice_0 *= 2
         other_values = delete(values_shift, 0, axis=axes[-1])
         values = insert(other_values, 0, slice_0, axis=axes[-1])
         values_IFT = irfftn(values, axes=axes)

--- a/SciDataTool/Functions/nudft_functions.py
+++ b/SciDataTool/Functions/nudft_functions.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy import allclose, exp, linspace
 from numpy import max as np_max
 from numpy import min as np_min
-from numpy import moveaxis, ndarray, outer, tensordot
+from numpy import moveaxis, ndarray, outer, pi, tensordot
 
 
 def matrice_D(t: ndarray, f: ndarray) -> ndarray:

--- a/SciDataTool/Functions/nudft_functions.py
+++ b/SciDataTool/Functions/nudft_functions.py
@@ -2,10 +2,12 @@ from logging import getLogger
 from typing import Dict, List
 
 import numpy as np
+from numpy import all as np_all
 from numpy import allclose, exp, linspace
 from numpy import max as np_max
+from numpy import mean
 from numpy import min as np_min
-from numpy import moveaxis, ndarray, outer, pi, tensordot
+from numpy import moveaxis, ndarray, outer, pi, tensordot, where
 
 
 def matrice_D(t: ndarray, f: ndarray) -> ndarray:
@@ -37,14 +39,14 @@ def nudftn(a: ndarray, axes_dict: Dict[int, List[ndarray]]) -> ndarray:
         if idx_axe not in axes_fft:  # Check if DFT has to be performed
             # Extract space sampling and frequency sampling
             s, f = axes
-            assert np.all()
+
             # Check aliasing with criteria frequency < 1/2*mean(spacestep)
             # Other criteria may be used with min instead of mean : max(f)>(1/(2*min(space)))
             space = s[1:] - s[:-1]
-            if max(f) > (1 / (2 * mean(space))):
+            if np_max(f) > (1 / (2 * mean(space))):
                 # Display warning
                 print(
-                    f"The maximum frequency ({max(f)}) is greater than the 1/(2*mean of each timestep) ({1/(2*mean(space))}), aliasing may occur."
+                    f"The maximum frequency ({np_max(f)}) is greater than the 1/(2*mean of each timestep) ({1/(2*mean(space))}), aliasing may occur."
                 )
 
             # TODO criteria to have only positive freq or approximatively 50% of negative frequencies
@@ -60,7 +62,7 @@ def nudftn(a: ndarray, axes_dict: Dict[int, List[ndarray]]) -> ndarray:
             res /= len(s)
 
             # Check if every frequency is >=0 (rfft equivalent)
-            if all(f >= 0):
+            if np_all(f >= 0):
                 idx = where(f != 0)
                 slice_list = tuple(
                     slice(None) if i != idx_axe else idx[0] for i in range(res.ndim)

--- a/SciDataTool/Functions/nudft_functions.py
+++ b/SciDataTool/Functions/nudft_functions.py
@@ -1,0 +1,149 @@
+from logging import getLogger
+from typing import Dict, List
+
+import numpy as np
+from numpy import allclose, exp, linspace
+from numpy import max as np_max
+from numpy import min as np_min
+from numpy import moveaxis, ndarray, outer, tensordot
+
+
+def matrice_D(t: ndarray, f: ndarray) -> ndarray:
+    """
+    Construct discrete Fourier transform matrix
+    """
+    return exp(-1j * outer(f * 2 * pi, t))
+
+
+def nudftn(a: ndarray, axes_dict: Dict[int, List[ndarray]]) -> ndarray:
+    """
+    Compute the non uniform discrete Fourier Transform
+
+    Parameter
+    ---------
+
+    a: Input data
+    axes_dict: Axes to perform dft with corresponding space and freqsampling
+
+    Returns
+    res: DFT result
+    """
+    # Copy data
+    res = a.copy()
+
+    axes_fft = []
+    # Iterate on each axe to compute 1D DFT
+    for idx_axe, axes in axes_dict.items():
+        if idx_axe not in axes_fft:  # Check if DFT has to be performed
+            # Extract space sampling and frequency sampling
+            s, f = axes
+            assert np.all()
+            # Check aliasing with criteria frequency < 1/2*mean(spacestep)
+            # Other criteria may be used with min instead of mean : max(f)>(1/(2*min(space)))
+            space = s[1:] - s[:-1]
+            if max(f) > (1 / (2 * mean(space))):
+                # Display warning
+                print(
+                    f"The maximum frequency ({max(f)}) is greater than the 1/(2*mean of each timestep) ({1/(2*mean(space))}), aliasing may occur."
+                )
+
+            # TODO criteria to have only positive freq or approximatively 50% of negative frequencies
+
+            # Construct DFT matrix
+            D = matrice_D(s, f)
+
+            # Operate the matrix multiplication and move axis to keep the good shaê
+            res = tensordot(D, res, ((1,), (idx_axe)))
+            res = moveaxis(res, 0, idx_axe)
+
+            # Normalize by the number of frequencies
+            res /= len(s)
+
+            # Check if every frequency is >=0 (rfft equivalent)
+            if all(f >= 0):
+                idx = where(f != 0)
+                slice_list = tuple(
+                    slice(None) if i != idx_axe else idx[0] for i in range(res.ndim)
+                )
+                res[slice_list] *= 2
+
+    return res
+
+
+def matrice_E(t: ndarray, f: ndarray) -> ndarray:
+    """Construct inverse discrete Fourier transform matrix"""
+
+    return exp(1j * outer(t, f * 2 * pi))
+
+
+def inudftn(a: ndarray, axes_dict: Dict[int, List[ndarray]]) -> ndarray:
+    """
+    Compute the non uniform discrete Fourier Transform
+
+    Parameter
+    ---------
+
+    a: Input data
+    axes_dict: Axes to perform dft with corresponding space and freqsampling
+
+    Returns
+    res: DFT result
+    """
+
+    res = a.copy()
+
+    # TODO check axes to perform ifft if space and freq sampling are matching
+    # /!\ Normalization is done in inudft and not in fft, look in SciDataTool to find the
+    # right normalization
+    axes_fft = []
+
+    # Iterate on each axe to compute 1D DFT
+    for idx_axe, axes in axes_dict.items():
+        if idx_axe not in axes_fft:  # Check if DFT has to be performed
+            # Extract space sampling and frequency sampling
+            s, f = axes
+
+            # Construct DFT matrix
+            E = matrice_E(s, f)
+
+            # Operate the matrix multiplication and move axis to keep the good shape
+            res = tensordot(E, res, ((1,), (idx_axe)))
+            res = moveaxis(res, 0, idx_axe)
+
+    return res
+
+
+def is_uniform(vect_a, rtol=1e-05, atol=1e-8):
+    """
+    Tests if the array vect_a is uniform
+    Parameters
+    ----------
+    vect_a: array
+        Time or space vector
+    rtol: float
+        Relative tolerance parameter
+    atol: float
+        Absolut tolerance parameter
+    Returns
+    -------
+    y: boolean
+    boolean True if absolute(a - b) <= (atol + rtol * absolute(b))
+    """
+
+    assert type(vect_a) == type(ndarray(shape=())), TypeError(
+        "Time or space vector given must be a ndarray"
+    )
+    n = len(vect_a)
+
+    minimum = np_min(vect_a)
+    maximum = np_max(vect_a)
+
+    y = allclose(
+        vect_a,
+        linspace(minimum, maximum, n),
+        rtol=rtol,
+        atol=atol,
+        equal_nan=False,
+    )
+
+    return y

--- a/Tests/Validation/test_ndft.py
+++ b/Tests/Validation/test_ndft.py
@@ -1,0 +1,219 @@
+import numpy as np
+import random as rd
+import pytest
+
+from SciDataTool import Data1D, DataTime
+
+
+@pytest.mark.validation
+def test_nudft_1d():
+    """
+    Test DFT on non-uniform frequencies
+    """
+
+    def f_1d(x: np.ndarray) -> np.ndarray:
+        """
+        Create a 1D function with following Fourier transform coefficients:
+        - 4 at 0 Hz
+        - 20 at 4 Hz
+        - 16 at 6 Hz
+        - 10 at 20 Hz
+        """
+        return (
+            4
+            + 20 * np.sin(4 * 2 * np.pi * x)
+            + 16 * np.sin(6 * 2 * np.pi * x)
+            + 10 * np.sin(50 * 2 * np.pi * x)
+        )
+
+    # Define time discretization 200 samples
+    time = Data1D(name="time", unit="s", values=np.linspace(0, 1, 200))
+
+    # Define data
+    data = f_1d(time.values)
+    field = DataTime(
+        name="field",
+        symbol="X",
+        axes=[time],
+        values=data,
+        unit="m",
+    )
+
+    # Compute non uniform discrete Fourier transform
+    result_nudft = field.get_along(
+        "freqs=axis_data", axis_data={"freqs": np.array([0, 4, 6, 50])}
+    )
+
+    # Create results dict to check nudft amplitude coefficient
+    theoretical_amplitude_dict = {0: 4, 4: 20, 6: 16, 20: 10}
+
+    # Check amplitudes
+    for freq, val_fft in zip(result_nudft["freqs"], result_nudft["X"]):
+        assert (
+            np.abs(val_fft) == theoretical_amplitude_dict[freq]
+        ), f"Non uniform dft amplitude is different from the theoretical one : {np.abs(val_fft)}!={theoretical_amplitude_dict[freq]}"
+
+
+@pytest.mark.validation
+def test_inudft_1d():
+    """
+    Test iDFT on non-uniform frequencies
+    """
+
+    def f_1d(x: np.ndarray) -> np.ndarray:
+        """
+        Create a 1D function with following Fourier transform coefficients:
+        - 1 at 0 Hz
+        - 5 at 2 Hz
+        - 3 at 10 Hz
+        - 8 at 13 Hz
+        """
+        return (
+            1
+            + 5 * np.sin(2 * 2 * np.pi * x)
+            + 3 * np.sin(10 * 2 * np.pi * x)
+            + 8 * np.sin(13 * 2 * np.pi * x)
+        )
+
+    # Define time discretization 200 samples
+    time = Data1D(name="time", unit="s", values=np.linspace(0, 1, 200))
+
+    # Define data
+    data = f_1d(time.get_values())
+
+    field = DataTime(
+        name="field",
+        symbol="X",
+        axes=[time],
+        values=data,
+        unit="dimless",
+    )
+
+    # Compute non uniform discrete Fourier transform
+    result_nudft = field.get_along(
+        "freqs=axis_data", axis_data={"freqs": np.array([0, 2, 10, 13])}
+    )
+
+    # Define the spectral exis
+    frequencies = Data1D(name="freqs", unit="Hz", values=result_nudft["freqs"])
+
+    # Define the spectrum over the axis frequencies
+    field = DataTime(
+        name="field",
+        symbol="X",
+        axes=[frequencies],
+        values=result_nudft["X"],
+        unit="dimless",
+    )
+
+    result_inudft = field.get_along(
+        "time=axis_data", axis_data={"time": np.linspace(0, 1, 200)}
+    )
+
+    np.testing.assert_array_almost_equal(result_inudft["X"], data)
+
+
+@pytest.mark.validation
+def test_force_nudft_1d():
+
+    time = Data1D(name="time", unit="s", values=np.linspace(0, 1, 200))
+
+    def f_1d(x):
+        """
+        Create a 1D function with following Fourier transform coefficients:
+        - 2 at 0 Hz
+        - 3 at 3 Hz
+        - 4 at 9 Hz
+        - 5 at 15 Hz
+        """
+        return (
+            2
+            + 3 * np.sin(3 * 2 * np.pi * x)
+            + 4 * np.sin(9 * 2 * np.pi * x)
+            + 5 * np.sin(15 * 2 * np.pi * x)
+        )
+
+    data = f_1d(time.get_values())
+
+    field = DataTime(
+        name="field",
+        symbol="X",
+        axes=[time],
+        values=data,
+        unit="dimless",
+    )
+
+    freqs = [i for i in range(200)]
+
+    # Compute discrete Fourier transform
+    result_fft = field.get_along(
+        "freqs=axis_data", axis_data={"freqs": np.array(freqs)}
+    )
+
+    # the last element of freqs must trigger is_uniform test
+    # epsilon = absolute(a - b) <= (atol + rtol * absolute(b))
+    # the default parameters - (ndft_functions -> is_uniform) are rtol=1e-05, atol=1e-18
+
+    freqs[-1] = freqs[-1] + 1e-8 + (1e-5 + 1e-6) * np.abs(freqs[-1])
+
+    # Compute non uniform discrete Fourier transform
+    result_nudft = field.get_along(
+        "freqs=axis_data", axis_data={"freqs": np.array(freqs)}
+    )
+
+    assert np.allclose(
+        result_fft["X"][:-1], result_nudft["X"][:-1]
+    ), "The FFT and NUDFT methods sould return approximatly the same results"
+
+
+@pytest.mark.validation
+def test_nudft_2d():
+    def f_2d(t, theta):
+        """
+        Create a 2D function with following Fourier transform coefficients:
+        - 1 at 0 Hz
+        - 2 at 15 Hz
+        Wavenumber:
+        - 3 at 10 {°}
+        """
+
+        return 1 + 3 * np.sin(10 * 2 * np.pi * theta) + 2 * np.sin(15 * 2 * np.pi * t)
+
+    time = Data1D(name="time", unit="s", values=np.linspace(0, 1, 200))
+    angle = Data1D(name="angle", unit="{°}", values=np.linspace(0, 360, 200))
+
+    angle_coord, time_coord = np.meshgrid(time.get_values(), angle.get_values())
+
+    field = f_2d(time_coord, angle_coord)
+
+    Field = DataTime(
+        name="Field", symbol="X", unit="dimless", axes=[time, angle], values=field
+    )
+
+    freqs_non_unif = np.linspace(0, 200, 400)
+    freqs_non_unif = rd.sample(list(freqs_non_unif), 200)
+    freqs_non_unif.sort()
+    freqs_non_unif = np.asarray(freqs_non_unif)
+
+    wavenumber_unif = [i for i in range(200)]
+
+    # Compute non uniform discrete Fourier transform
+    result_fft = field.get_along(
+        "freqs=axis_data",
+        "wavenumber=axis_data",
+        axis_data={
+            "freqs": np.array(freqs_non_unif),
+            "wavenumber": np.array(wavenumber_unif),
+        },
+    )
+
+    wavenumber = Data1D(name="wavenumber", unit="s", values=wavenumber)
+    freqs = Data1D(name="freqs", unit="Hz", values=freqs_non_unif)
+
+    angle_coord, time_coord = np.meshgrid(time.get_values(), angle.get_values())
+
+    field = f_d(time_coord, angle_coord)
+
+    Field = DataTime(
+        name="Field", symbol="X", unit="dimless", axes=[time, angle], values=field
+    )


### PR DESCRIPTION
This PR introduces a way to solve partially issue #9 by computing (inverse) Fourier transform on sparse/non uniform frequencies and/or time. 

The method uses the naive implementation of discrete Fourier transform . 

If user has an _a priori_ knowledge on spectrum sparsity, it can be used to store the signal in Fourier domain. 
Such signal can then be approximately reconstructed in time domain using inverse DFT. An example is given bellow.

As the method is based on DFT, it should be used only on sparse signal, otherwise, it is better to use the FFT. 

Further improvement may be done such as implementation of [NUFFT](https://github.com/Eomys/SciDataTool/issues/9#issuecomment-827733660). 

Different examples are written in this [test file](https://github.com/Eomys/SciDataTool/blob/master/Tests/Validation/test_ndft.py).

Example: 
```py
def f_1d(x: np.ndarray) -> np.ndarray:
    """
    Create a 1D function with following Fourier transform coefficients:
    - 4 at 0 Hz
    - 20 at 4 Hz
    - 16 at 6 Hz
    - 10 at 20 Hz
    """
    return (
        4
        + 20 * np.sin(4 * 2 * np.pi * x)
        + 16 * np.sin(6 * 2 * np.pi * x)
        + 10 * np.sin(50 * 2 * np.pi * x)
    )

# Define time discretization 200 samples
time = Data1D(name="time", unit="s", values=np.linspace(0, 1, 200))

# Define data
data = f_1d(time.values)
field = DataTime(
    name="field",
    symbol="X",
    axes=[time],
    values=data,
    unit="m",
)

# Compute non uniform discrete Fourier transform
result_nudft = field.get_along(
    "freqs=axis_data", axis_data={"freqs": np.array([0, 4, 6, 50])}
)

# Define the spectral axe
frequencies = Data1D(name="freqs", unit="Hz", values=result_nudft["freqs"])

# Define the spectrum over the axis frequencies
data_freq = DataFreq(
    name="field",
    symbol="X",
    axes=[frequencies],
    values=result_nudft["X"],
    unit="dimless",
)

# Compute inverse non uniform discrete Fourier transform
result_inudft = data_freq.get_along("time=axis_data", axis_data={"time": time_vect})
```