### PR TITLE
[BC] fix is_outside_legend bypassing is_show_legend parameter in plot_2D

### DIFF
--- a/SciDataTool/Functions/Plot/plot_2D.py
+++ b/SciDataTool/Functions/Plot/plot_2D.py
@@ -400,11 +400,11 @@ def plot_2D(
     if not no_legend:
         ax.legend(prop={"family": font_name, "size": font_size_legend})
 
-    if not is_show_legend:
-        ax.get_legend().remove()
-
     if is_outside_legend:
         ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
+
+    if not is_show_legend:
+        ax.get_legend().remove()
 
     plt.tight_layout()
     for item in (


### PR DESCRIPTION
When `is_show_legend` is False and `is_outside_legend` is True, legend was still displayed.

Interverting the two conditions solve the problem.