### PR TITLE
New features for the pcolormesh type of the plot_3D function

### DIFF
--- a/SciDataTool/Functions/Plot/plot_3D.py
+++ b/SciDataTool/Functions/Plot/plot_3D.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import mpl_toolkits.mplot3d.art3d as art3d
 from matplotlib.image import NonUniformImage
 import matplotlib
+import matplotlib.colors as colors
 
 from SciDataTool.Functions.Plot.init_fig import init_fig
 from SciDataTool.Functions.Plot import COLORS
@@ -47,6 +48,7 @@ def plot_3D(
     font_size_label=10,
     font_size_legend=8,
     levels=None,
+    is_log_cmap=False,
 ):
     """Plots a 3D graph ("stem", "surf" or "pcolor")
 
@@ -277,17 +279,29 @@ def plot_3D(
             shading = "flat"
         else:
             shading = "gouraud"
-        c = ax.pcolormesh(
-            Xdata,
-            Ydata,
-            Zdata,
-            cmap=colormap,
-            shading=shading,
-            antialiased=True,
-            picker=True,
-            vmin=z_min,
-            vmax=z_max,
-        )
+        if is_log_cmap:
+            c = ax.pcolormesh(
+                Xdata,
+                Ydata,
+                Zdata,
+                cmap=colormap,
+                shading=shading,
+                antialiased=True,
+                picker=True,
+                norm=colors.LogNorm(vmin=z_min, vmax=z_max),
+            )
+        else :
+            c = ax.pcolormesh(
+                Xdata,
+                Ydata,
+                Zdata,
+                cmap=colormap,
+                shading=shading,
+                antialiased=True,
+                picker=True,
+                vmin=z_min,
+                vmax=z_max,
+            )
         clb = fig.colorbar(c, ax=ax)
         clb.ax.set_title(zlabel, fontsize=font_size_legend, fontname=font_name)
         clb.ax.tick_params(labelsize=font_size_legend)

--- a/SciDataTool/Functions/Plot/plot_3D.py
+++ b/SciDataTool/Functions/Plot/plot_3D.py
@@ -98,9 +98,9 @@ def plot_3D(
     is_disp_title : bool
         boolean indicating if the title must be displayed
     type_plot : str
-        type of 3D graph : "stem", "surf", "pcolor" or "scatter"
+        type of 3D graph : "stem", "surf", "pcolor", "pcolormesh" or "scatter"
     is_contour : bool
-        True to show contour line if type_plot = "pcolor"
+        True to show contour line if type_plot = "pcolor" or "pcolormesh"
     is_shading_flat : bool
         True to use flat shading instead of Gouraud for pcolormesh or bilinear for pcolor
     save_path : str
@@ -109,10 +109,10 @@ def plot_3D(
         True to show figure after plot
     is_switch_axes : bool
         to switch x and y axes
-    levels : list
+    levels : list of float or int
         the levels for the contour to be drawn if is_contour is True and type_plot is "pcolormesh"
         if None, the levels will be determined automatically 
-    gamma : float
+    gamma : int or float
         the power of the PowerNorm that can be used if type_plot is "pcolormesh"
     n_ticks : int
         the number of ticks that will be displayed on the colorbar if type_plot is "pcolormesh" and

--- a/SciDataTool/Functions/Plot/plot_3D.py
+++ b/SciDataTool/Functions/Plot/plot_3D.py
@@ -296,7 +296,6 @@ def plot_3D(
                 CS = ax.contour(Xdata, Ydata, Zdata, colors="black", linewidths=0.8)
             else :
                 CS = ax.contour(Xdata, Ydata, Zdata, colors="black", linewidths=0.8, levels=levels)
-            print(CS.levels)
             ax.clabel(CS, CS.levels, inline=True, fmt="%4g", fontsize=font_size_legend)
         for l in clb.ax.yaxis.get_ticklabels():
             l.set_family(font_name)

--- a/SciDataTool/Functions/Plot/plot_3D.py
+++ b/SciDataTool/Functions/Plot/plot_3D.py
@@ -291,6 +291,10 @@ def plot_3D(
                 picker=True,
                 norm=colors.PowerNorm(vmin=z_min, vmax=z_max,gamma=gamma),
             )
+            # Number of ticks on the colorbar 
+            N=7
+            ticks=[z_min+i**(1/gamma)*(z_max-z_min)/(N-1)**(1/gamma) for i in range(N)]
+            clb = fig.colorbar(c, ax=ax, ticks=ticks)
         else :
             c = ax.pcolormesh(
                 Xdata,
@@ -303,7 +307,7 @@ def plot_3D(
                 vmin=z_min,
                 vmax=z_max,
             )
-        clb = fig.colorbar(c, ax=ax)
+            clb = fig.colorbar(c, ax=ax)
         clb.ax.set_title(zlabel, fontsize=font_size_legend, fontname=font_name)
         clb.ax.tick_params(labelsize=font_size_legend)
         if is_contour:

--- a/SciDataTool/Functions/Plot/plot_3D.py
+++ b/SciDataTool/Functions/Plot/plot_3D.py
@@ -292,10 +292,12 @@ def plot_3D(
         clb.ax.set_title(zlabel, fontsize=font_size_legend, fontname=font_name)
         clb.ax.tick_params(labelsize=font_size_legend)
         if is_contour:
-            CS = ax.contour(Xdata, Ydata, Zdata, colors="black", linewidths=0.8)
             if levels is None:
-                levels = CS.levels
-            ax.clabel(CS, levels, inline=True, fmt="%4g", fontsize=font_size_legend)
+                CS = ax.contour(Xdata, Ydata, Zdata, colors="black", linewidths=0.8)
+            else :
+                CS = ax.contour(Xdata, Ydata, Zdata, colors="black", linewidths=0.8, levels=levels)
+            print(CS.levels)
+            ax.clabel(CS, CS.levels, inline=True, fmt="%4g", fontsize=font_size_legend)
         for l in clb.ax.yaxis.get_ticklabels():
             l.set_family(font_name)
         if xticks is not None:

--- a/SciDataTool/Functions/Plot/plot_3D.py
+++ b/SciDataTool/Functions/Plot/plot_3D.py
@@ -1,4 +1,4 @@
-from numpy import nanmin as np_min, nanmax as np_max, abs as np_abs, log10
+from numpy import nanmin as np_min, nanmax as np_max, abs as np_abs, log10, linspace
 
 import matplotlib.pyplot as plt
 import mpl_toolkits.mplot3d.art3d as art3d
@@ -49,6 +49,7 @@ def plot_3D(
     font_size_legend=8,
     levels=None,
     is_log_cmap=False,
+    gamma=1
 ):
     """Plots a 3D graph ("stem", "surf" or "pcolor")
 
@@ -288,7 +289,7 @@ def plot_3D(
                 shading=shading,
                 antialiased=True,
                 picker=True,
-                norm=colors.LogNorm(vmin=z_min, vmax=z_max),
+                norm=colors.PowerNorm(vmin=z_min, vmax=z_max,gamma=gamma),
             )
         else :
             c = ax.pcolormesh(

--- a/SciDataTool/Functions/Plot/plot_3D.py
+++ b/SciDataTool/Functions/Plot/plot_3D.py
@@ -46,6 +46,7 @@ def plot_3D(
     font_size_title=12,
     font_size_label=10,
     font_size_legend=8,
+    levels=None,
 ):
     """Plots a 3D graph ("stem", "surf" or "pcolor")
 
@@ -292,7 +293,9 @@ def plot_3D(
         clb.ax.tick_params(labelsize=font_size_legend)
         if is_contour:
             CS = ax.contour(Xdata, Ydata, Zdata, colors="black", linewidths=0.8)
-            ax.clabel(CS, CS.levels, inline=True, fmt="4g", fontsize=font_size_legend)
+            if levels is None:
+                levels = CS.levels
+            ax.clabel(CS, levels, inline=True, fmt="%4g", fontsize=font_size_legend)
         for l in clb.ax.yaxis.get_ticklabels():
             l.set_family(font_name)
         if xticks is not None:

--- a/SciDataTool/Functions/Plot/plot_3D.py
+++ b/SciDataTool/Functions/Plot/plot_3D.py
@@ -48,8 +48,8 @@ def plot_3D(
     font_size_label=10,
     font_size_legend=8,
     levels=None,
-    is_log_cmap=False,
-    gamma=1
+    gamma=1,
+    n_ticks = 7,
 ):
     """Plots a 3D graph ("stem", "surf" or "pcolor")
 
@@ -109,6 +109,14 @@ def plot_3D(
         True to show figure after plot
     is_switch_axes : bool
         to switch x and y axes
+    levels : list
+        the levels for the contour to be drawn if is_contour is True and type_plot is "pcolormesh"
+        if None, the levels will be determined automatically 
+    gamma : float
+        the power of the PowerNorm that can be used if type_plot is "pcolormesh"
+    n_ticks : int
+        the number of ticks that will be displayed on the colorbar if type_plot is "pcolormesh" and
+        gamma != 1
     """
 
     # Set if figure must be shown if is_show_fig is None
@@ -280,22 +288,7 @@ def plot_3D(
             shading = "flat"
         else:
             shading = "gouraud"
-        if is_log_cmap:
-            c = ax.pcolormesh(
-                Xdata,
-                Ydata,
-                Zdata,
-                cmap=colormap,
-                shading=shading,
-                antialiased=True,
-                picker=True,
-                norm=colors.PowerNorm(vmin=z_min, vmax=z_max,gamma=gamma),
-            )
-            # Number of ticks on the colorbar 
-            N=7
-            ticks=[z_min+i**(1/gamma)*(z_max-z_min)/(N-1)**(1/gamma) for i in range(N)]
-            clb = fig.colorbar(c, ax=ax, ticks=ticks)
-        else :
+        if gamma==1:
             c = ax.pcolormesh(
                 Xdata,
                 Ydata,
@@ -308,6 +301,21 @@ def plot_3D(
                 vmax=z_max,
             )
             clb = fig.colorbar(c, ax=ax)
+        else :
+            c = ax.pcolormesh(
+                Xdata,
+                Ydata,
+                Zdata,
+                cmap=colormap,
+                shading=shading,
+                antialiased=True,
+                picker=True,
+                norm=colors.PowerNorm(vmin=z_min, vmax=z_max,gamma=gamma),
+            )
+            # Number of ticks on the colorbar 
+            N=n_ticks
+            ticks=[z_min+i**(1/gamma)*(z_max-z_min)/(N-1)**(1/gamma) for i in range(N)]
+            clb = fig.colorbar(c, ax=ax, ticks=ticks)
         clb.ax.set_title(zlabel, fontsize=font_size_legend, fontname=font_name)
         clb.ax.tick_params(labelsize=font_size_legend)
         if is_contour:


### PR DESCRIPTION
This PR enables to manually set the levels of the contours and to use a matplotlib.colors.PowerNorm to better control the colors when a pcolormesh is used in the plot_3D function.