### PR TITLE
Update requirements and added tests for latest Python versions (3.7 to 3.14)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _Internal/
 .ipynb_checkpoints/
 SciDataTool.egg-info
 dist
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ _Internal/
 .ipynb_checkpoints/
 SciDataTool.egg-info
 dist
-.venv/
+.*venv*/
+.tox/
+.vscode/

--- a/SciDataTool/Classes/_check.py
+++ b/SciDataTool/Classes/_check.py
@@ -1,4 +1,4 @@
-from numpy import array, empty, int32, squeeze, expand_dims
+from numpy import array, empty, int32, int64, squeeze, expand_dims
 
 
 def set_array(obj, prop, value):
@@ -108,8 +108,7 @@ def check_type(var_name, value, expect_type, type_value):
     """
     if expect_type == "float":  # float variable can take int value
         if not (
-            (isinstance(value, int32) and not isinstance(value, bool))
-            or (isinstance(value, int) and not isinstance(value, bool))
+            (isinstance(value, (int32, int, int64)) and not isinstance(value, bool))
             or isinstance(value, float)
         ):
             raise CheckTypeError(

--- a/SciDataTool/Functions/Load/load_hdf5.py
+++ b/SciDataTool/Functions/Load/load_hdf5.py
@@ -1,5 +1,5 @@
 from h5py import File, Group
-from numpy import bool_, int64, string_, array
+from numpy import bool_, int64, str_, array
 from cloudpickle import loads
 
 
@@ -37,7 +37,7 @@ def construct_dict_from_group(group):
                     value = bool(value)
                 elif isinstance(value, int64):  # float
                     value = float(value)
-                elif isinstance(value, string_):  # String
+                elif isinstance(value, str_):  # String
                     value = value.decode("ISO-8859-2")
 
                 list_.append(value)
@@ -58,7 +58,7 @@ def construct_dict_from_group(group):
                     value = bool(value)
                 elif isinstance(value, int64):  # float
                     value = float(value)
-                elif isinstance(value, string_):  # String
+                elif isinstance(value, str_):  # String
                     value = value.decode("ISO-8859-2")
                 dict_[key] = value
         return dict_

--- a/SciDataTool/Functions/Load/load_hdf5.py
+++ b/SciDataTool/Functions/Load/load_hdf5.py
@@ -1,6 +1,6 @@
-from h5py import File, Group
-from numpy import bool_, int64, str_, array
 from cloudpickle import loads
+from h5py import File, Group
+from numpy import array, bool_, bytes_, int64
 
 
 def construct_dict_from_group(group):
@@ -37,7 +37,10 @@ def construct_dict_from_group(group):
                     value = bool(value)
                 elif isinstance(value, int64):  # float
                     value = float(value)
-                elif isinstance(value, str_):  # String
+                elif isinstance(value, bytes_):  # String
+                    # np.string_ has been removed in 2.0.0. See
+                    # https://numpy.org/doc/stable/release/2.0.0-notes.html for details.
+                    # its recommended to use np.bytes_ instead.
                     value = value.decode("ISO-8859-2")
 
                 list_.append(value)
@@ -58,7 +61,7 @@ def construct_dict_from_group(group):
                     value = bool(value)
                 elif isinstance(value, int64):  # float
                     value = float(value)
-                elif isinstance(value, str_):  # String
+                elif isinstance(value, bytes_):  # String
                     value = value.decode("ISO-8859-2")
                 dict_[key] = value
         return dict_

--- a/SciDataTool/Functions/Plot/plot_3D.py
+++ b/SciDataTool/Functions/Plot/plot_3D.py
@@ -260,7 +260,7 @@ def plot_3D(
         #     # Enabling transposition
         im.set_data(Xdata, Ydata, Zdata)
         im.set_clim(z_min, z_max)
-        ax.images.append(im)
+        ax.add_image(im)
         if is_contour:
             # if Zdata.shape[0] == Xdata.size:
             #     ax.contour(Xdata, Ydata, Zdata.T, colors="black", linewidths=0.8)

--- a/SciDataTool/Functions/Plot/plot_4D.py
+++ b/SciDataTool/Functions/Plot/plot_4D.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from numpy import log10, abs as np_abs, nanmax as np_max, NaN, zeros_like
+from numpy import log10, abs as np_abs, nanmax as np_max, nan, zeros_like
 import matplotlib.pyplot as plt
 
 from SciDataTool.Functions.Plot.init_fig import init_fig
@@ -157,7 +157,7 @@ def plot_4D(
         else:
             z_min = z_max / 1e4
 
-    Zdata[Zdata < z_min] = NaN
+    Zdata[Zdata < z_min] = nan
 
     if is_same_size:
         Sdata = zeros_like(Zdata)

--- a/SciDataTool/Functions/derivation_integration.py
+++ b/SciDataTool/Functions/derivation_integration.py
@@ -251,7 +251,13 @@ def integrate(values, ax_val, index, Nper, is_aper, is_phys, is_mean=False):
                 # in case of periodicity (respectively anti-periodicity)
                 values_full[-1, ...] = values[0, ...]
             # Integrate along axis
-            values = Nper * np.trapz(values_full, x=ax_full, axis=0)
+            try:
+                values = Nper * np.trapz(values_full, x=ax_full, axis=0)
+            except AttributeError:
+                # trapz was deprecated in numpy 2.0
+                values = Nper * np.trapezoid(values_full, x=ax_full, axis=0)
+            except Exception as e:
+                raise e
             # Readd first dim and swap axes back to origin
             values = np.swapaxes(values[None, ...], 0, index)
 

--- a/Tests/Validation/test_fft.py
+++ b/Tests/Validation/test_fft.py
@@ -1,4 +1,3 @@
-from pandas import NA
 import pytest
 from SciDataTool import (
     DataTime,

--- a/Tests/Validation/test_plot.py
+++ b/Tests/Validation/test_plot.py
@@ -42,6 +42,16 @@ def test_plot_2D(axis1, axis2, plot_name):
         ("time", r"angle{°}", True, "plot_3D_flat"),
         ("time", r"angle{°}", False, "plot_3D"),
         ("freqs", "wavenumber", True, "plot_3D_freqs_wavenumber_flat"),
+        pytest.param(
+            "freqs",
+            "wavenumber",
+            False,
+            "plot_3D_freqs_wavenumber_stem",
+            marks=pytest.mark.xfail(
+                reason="There is some issue with the axis data configuration in 3D plot "
+                "when using fft and is_2D_view=False"
+            ),
+        ),
     ],
 )
 def test_plot_3D(axis1, axis2, view_2D, plot_name):

--- a/Tests/Validation/test_plot.py
+++ b/Tests/Validation/test_plot.py
@@ -1,14 +1,24 @@
-import pytest
-from SciDataTool import DataLinspace, DataTime, Data1D, Norm_affine
-from Tests import save_validation_path
-from SciDataTool.Functions.Plot.plot_2D import plot_2D
-from numpy import meshgrid, pi, linspace, zeros, sin, split, sum
 from os.path import join
+
+import pytest
+from numpy import cos, linspace, meshgrid, pi, sin, zeros
+
+from SciDataTool import Data1D, DataLinspace, DataTime, Norm_affine
+from Tests import save_validation_path
 
 
 @pytest.mark.validation
 # @pytest.mark.DEV
-def test_plot():
+@pytest.mark.parametrize(
+    ("axis1", "axis2", "plot_name"),
+    [
+        ("time", "angle=[0,pi/4,pi/2]", "plot_2D"),
+        ("freqs", "angle=[0,pi/4,pi/2]", "plot_2D_freqs"),
+        ("wavenumber", "", "plot_2D_wavenumber"),
+        ("wavenumber", r"freqs=1{Hz}", "plot_2D_wavenumber_freq"),
+    ],
+)
+def test_plot_2D(axis1, axis2, plot_name):
     """Test plot"""
     Time = DataLinspace(name="time", unit="s", initial=0, final=10, number=1001)
     Angle = DataLinspace(name="angle", unit="rad", initial=0, final=2 * pi, number=2001)
@@ -17,17 +27,44 @@ def test_plot():
     Field = DataTime(name="Example field", symbol="Z", axes=[Time, Angle], values=field)
 
     Field.plot_2D_Data(
-        "time",
-        "angle=[0,pi/4,pi/2]",
+        axis1,
+        axis2,
         is_show_fig=False,
-        save_path=join(save_validation_path, "plot_2D.png"),
+        save_path=join(save_validation_path, f"{plot_name}.png"),
     )
+
+
+@pytest.mark.validation
+# @pytest.mark.DEV
+@pytest.mark.parametrize(
+    ("axis1", "axis2", "view_2D", "plot_name"),
+    [
+        ("time", r"angle{°}", True, "plot_3D_flat"),
+        ("time", r"angle{°}", False, "plot_3D"),
+        ("freqs", "wavenumber", True, "plot_3D_freqs_wavenumber_flat"),
+    ],
+)
+def test_plot_3D(axis1, axis2, view_2D, plot_name):
+    """Test plot"""
+    Time = DataLinspace(name="time", unit="s", initial=0, final=2, number=1001)
+    Angle = DataLinspace(name="angle", unit="rad", initial=0, final=2 * pi, number=2001)
+    angle, time = meshgrid(Angle.get_values(), Time.get_values())
+
+    # wave parameters
+    f = 1
+    omega = 2 * pi * f  # angular frequency (rad/s)
+    k = 1.0  # angular wavenumber (rad⁻¹)
+    phi = 0.0  # phase offset
+
+    field = 3 * sin(omega * time + 1 * angle) + cos(2 * omega * time + 5 * angle)
+    Field = DataTime(name="Example field", symbol="Z", axes=[Time, Angle], values=field)
+
     Field.plot_3D_Data(
-        "time",
-        "angle{°}",
-        is_2D_view=True,
+        axis1,
+        axis2,
+        is_2D_view=view_2D,
         is_show_fig=False,
-        save_path=join(save_validation_path, "plot_3D.png"),
+        save_path=join(save_validation_path, f"{plot_name}.png"),
     )
 
 
@@ -103,6 +140,5 @@ def test_strings():
 
 
 if __name__ == "__main__":
-    test_plot()
     test_normalization()
     test_strings()

--- a/Tests/Validation/test_slice.py
+++ b/Tests/Validation/test_slice.py
@@ -1,6 +1,6 @@
 import pytest
 from SciDataTool import DataLinspace, DataTime, DataPattern
-from numpy import meshgrid, linspace, array, repeat, nan, trapz, pi, cos
+from numpy import meshgrid, linspace, array, repeat, nan, pi, cos
 from numpy.testing import assert_array_almost_equal
 
 

--- a/Tests/__init__.py
+++ b/Tests/__init__.py
@@ -1,11 +1,33 @@
 import logging
-from os.path import join, abspath, dirname, isdir
+import sys
 from os import makedirs
+from os.path import abspath, dirname, isdir, join
 from shutil import rmtree
-from matplotlib import use
 
-# Use Qt5/Qt6 backend depended on whats installed (PyQt5/PySide2 or PyQt6/PySide6)
-use("qtagg")
+from matplotlib import use
+from packaging.version import Version
+
+# check python version for import of pyside2 or pyside6
+PYTHON_VERSION = Version(sys.version.split(" ")[0])
+if PYTHON_VERSION <= Version("3.9"):
+    try:
+        from PySide2 import QtCore
+
+        # Use Qt5/Qt6 backend depended on whats installed (PyQt5/PySide2 or PyQt6/PySide6)
+        use("qtagg")
+    except ImportError:
+        use("agg")
+elif PYTHON_VERSION > Version("3.9"):
+    try:
+        from PySide6 import QtCore
+
+        # Use Qt5/Qt6 backend depended on whats installed (PyQt5/PySide2 or PyQt6/PySide6)
+        use("qtagg")
+    except ImportError:
+        use("agg")
+else:
+    logging.error("Invalid python version %s", sys.version_info)
+
 TEST_DIR = abspath(dirname(__file__))
 DATA_DIR = join(TEST_DIR, "Data")
 LOG_DIR = join(TEST_DIR, "logtest.txt")

--- a/Tests/__init__.py
+++ b/Tests/__init__.py
@@ -4,7 +4,8 @@ from os import makedirs
 from shutil import rmtree
 from matplotlib import use
 
-use("Qt5Agg")  # Use PyQt5 backend
+# Use Qt5/Qt6 backend depended on whats installed (PyQt5/PySide2 or PyQt6/PySide6)
+use("qtagg")
 TEST_DIR = abspath(dirname(__file__))
 DATA_DIR = join(TEST_DIR, "Data")
 LOG_DIR = join(TEST_DIR, "logtest.txt")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ scipy>=1.4.1
 matplotlib>=3.3.2
 h5py>=3.2.1
 cloudpickle>=1.3.0
-pytest>=5.4.1
 scikit-learn
+imageio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>1.19.5
-scipy>=1.4.1
+scipy>=1.6.0
 matplotlib>=3.3.2
 h5py>=3.2.1
 cloudpickle>=1.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 # Inside of setup.cfg
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/tox.toml
+++ b/tox.toml
@@ -1,0 +1,31 @@
+requires = ["tox>=4.19"]
+env_list = [
+    "py314",
+    "py313",
+    "py312",
+    "py311",
+    "py310",
+    "py39",
+    "py38",
+    "py37",
+    # "type"
+]
+
+[env_run_base]
+description = "Run test under {base_python}"
+deps = [
+    "pytest",
+    "PySide6;python_version>='3.10'",
+    "PySide2>=5.15.2;python_version<'3.10'",
+    # "PyQt5",
+]
+commands = [["pytest"]]
+
+# [env.type]
+# description = "run type check on code base"
+# deps = [
+#     "mypy==1.18.2",
+#     "types-cachetools>=5.5.0.20240820",
+#     "types-chardet>=5.0.4.6",
+# ]
+# commands = [["mypy", "scidatatool"], ["mypy", "Tests"]]

--- a/tox.toml
+++ b/tox.toml
@@ -8,6 +8,7 @@ env_list = [
     "py39",
     "py38",
     "py37",
+    # "py36", -> not compatible due to scipy 1.6.0
     # "type"
 ]
 


### PR DESCRIPTION
Hi Everyone,

this MR solves the issues with current dependency limitations according to issue #114, namely:
- numpy.string_ is depreciated and replaced by numpy.bytes_ (since numpy 2.0.0)
- numpy.NaN is replaced by numpy.nan (since numpy 2.0.0)
- numpy.trapz is replaced by numpy.trapezoid (since numpy 2.0.0)
- matplotlibs ax.images.append is replaced by ax.add_image
- improved matplotlib backend selection (PySide2 or 6) in tests depended on Python version.
- added imageio to requirements (used for animations)
. added tox setup to automatically run installation and tests for Python 3.7 to 3.14 (all working for their latest versions on my Windows)
- scipy min version up to 1.6.0 because of renaming trapz -> trapezoid (excludes Python 3.6)

